### PR TITLE
Use the latest SDK (do not merge before 2.5.0)

### DIFF
--- a/jupyter-docker/scripts/run-docker
+++ b/jupyter-docker/scripts/run-docker
@@ -64,7 +64,7 @@ DOCKER_DIRECTORY=$2
 shift 2
 FRAMEWORK="tf2"
 PORT=44300
-POPLAR_VERSION="2.4.0"
+POPLAR_VERSION="latest"
 USE_JUPYTER_IMAGE="-jupyter"
 
 for i in "$@"; do


### PR DESCRIPTION
With this PR the default build of the container will follow the latest SDK (not to be merged before 2.5.0 is released)